### PR TITLE
[FEAT] JwtFilter, JwtUtil 추가 및 회원 더미데이터 비밀번호 수정

### DIFF
--- a/src/main/java/com/leesang/mylocaldiary/member/controller/MemberController.java
+++ b/src/main/java/com/leesang/mylocaldiary/member/controller/MemberController.java
@@ -1,0 +1,15 @@
+package com.leesang.mylocaldiary.member.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/member")
+public class MemberController {
+
+    @GetMapping("/testJwtFilter")
+    public String testJwtFilter() {
+        return "testJwtFilter";
+    }
+}

--- a/src/main/java/com/leesang/mylocaldiary/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/leesang/mylocaldiary/security/config/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package com.leesang.mylocaldiary.security.config;
 import com.leesang.mylocaldiary.security.filter.CustomAuthenticationFilter;
 import com.leesang.mylocaldiary.security.filter.CustomAuthenticationProvider;
 import com.leesang.mylocaldiary.security.filter.JwtFilter;
+import com.leesang.mylocaldiary.security.handler.JwtAuthenticationEntryPoint;
 import com.leesang.mylocaldiary.security.jwt.JwtProvider;
 import com.leesang.mylocaldiary.security.jwt.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,11 +30,13 @@ public class WebSecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final JwtUtil jwtUtil;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Autowired
-    public WebSecurityConfig(JwtProvider jwtProvider, JwtUtil jwtUtil) {
+    public WebSecurityConfig(JwtProvider jwtProvider, JwtUtil jwtUtil, JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) {
         this.jwtProvider = jwtProvider;
         this.jwtUtil = jwtUtil;
+        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
     }
 
     @Bean
@@ -53,6 +56,9 @@ public class WebSecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                )
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers(new AntPathRequestMatcher("/api/auth/**")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/follow/**")).permitAll() // follow 허용
@@ -62,7 +68,6 @@ public class WebSecurityConfig {
                         .requestMatchers(new AntPathRequestMatcher("/api/posts/**")).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilter(customAuthenticationFilter) // 🔥 customAuthenticationFilter 추가
                 .cors(cors -> cors
                         .configurationSource(request -> {
                             CorsConfiguration config = new CorsConfiguration();

--- a/src/main/java/com/leesang/mylocaldiary/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/leesang/mylocaldiary/security/config/WebSecurityConfig.java
@@ -2,7 +2,9 @@ package com.leesang.mylocaldiary.security.config;
 
 import com.leesang.mylocaldiary.security.filter.CustomAuthenticationFilter;
 import com.leesang.mylocaldiary.security.filter.CustomAuthenticationProvider;
+import com.leesang.mylocaldiary.security.filter.JwtFilter;
 import com.leesang.mylocaldiary.security.jwt.JwtProvider;
+import com.leesang.mylocaldiary.security.jwt.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,10 +28,12 @@ import java.util.Arrays;
 public class WebSecurityConfig {
 
     private final JwtProvider jwtProvider;
+    private final JwtUtil jwtUtil;
 
     @Autowired
-    public WebSecurityConfig(JwtProvider jwtProvider) {
+    public WebSecurityConfig(JwtProvider jwtProvider, JwtUtil jwtUtil) {
         this.jwtProvider = jwtProvider;
+        this.jwtUtil = jwtUtil;
     }
 
     @Bean
@@ -69,7 +73,8 @@ public class WebSecurityConfig {
                             return config;
                         })
                 )
-                .addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/leesang/mylocaldiary/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/leesang/mylocaldiary/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.leesang.mylocaldiary.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leesang.mylocaldiary.common.response.CommonResponseVO;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 변환용
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401로 세팅
+        response.setContentType("application/json;charset=UTF-8");
+
+        CommonResponseVO<?> res = CommonResponseVO.builder().
+                status(HttpServletResponse.SC_UNAUTHORIZED)
+                .message("잘못된 인증 정보입니다.")
+                .data(null).
+                build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(res));
+    }
+}

--- a/src/main/java/com/leesang/mylocaldiary/security/jwt/JwtFilter.java
+++ b/src/main/java/com/leesang/mylocaldiary/security/jwt/JwtFilter.java
@@ -57,6 +57,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
                 SecurityContextHolder.getContext().setAuthentication(authenticationToken);
                 log.info("JWT 인증 성공 - loginId: {}", loginId);
+                log.info("JWT 인증 성공 - role: {}", role);
             }
         }
 

--- a/src/main/java/com/leesang/mylocaldiary/security/jwt/JwtFilter.java
+++ b/src/main/java/com/leesang/mylocaldiary/security/jwt/JwtFilter.java
@@ -1,0 +1,66 @@
+package com.leesang.mylocaldiary.security.filter;
+
+import com.leesang.mylocaldiary.security.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String bearerToken = request.getHeader("Authorization");
+
+        // 1. 토큰 꺼내기
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7); // "Bearer " 제거
+
+            // 2. 토큰 유효성 검증
+            if (jwtUtil.validateToken(token)) {
+                Claims claims = jwtUtil.getClaims(token);
+
+                String loginId = claims.get("email", String.class); // 🔥 우리가 넣은건 email (loginId)
+                String role = claims.get("role", String.class);
+
+                // 3. 인증 객체 만들어서 SecurityContext에 저장
+                UsernamePasswordAuthenticationToken authenticationToken =
+                        new UsernamePasswordAuthenticationToken(
+                                loginId,
+                                null,
+                                Collections.singleton(() -> role) // 🔥 권한은 하나만 세팅
+                        );
+
+                authenticationToken.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
+
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                log.info("JWT 인증 성공 - loginId: {}", loginId);
+            }
+        }
+
+        // 4. 다음 필터로 넘김
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/leesang/mylocaldiary/security/jwt/JwtUtil.java
+++ b/src/main/java/com/leesang/mylocaldiary/security/jwt/JwtUtil.java
@@ -1,0 +1,50 @@
+package com.leesang.mylocaldiary.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final Key key;
+
+    public JwtUtil(@Value("${token.secret}") String secretKey) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+    }
+
+    // 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰이 비어있습니다.");
+        }
+        return false;
+    }
+
+    // Claims 추출
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/resources/sql/member_test_data.sql
+++ b/src/main/resources/sql/member_test_data.sql
@@ -1,11 +1,21 @@
-insert into member
-(login_id, password, email, role, birth, nickname, status)
-values
-("test01", "$2a$12$//JXeAX/llnIhe1kOOZVCeC21eb2TOr2hZdF6PyQNKKri7t1nKHB."
-, "test01@test.com", "MEMBER", "2000-03-09", "test01", "ACTIVE");
+-- member (회원)
+INSERT INTO member (id, login_id, password, name, email, nickname, bio, created_at, status, role, profile_image)
+VALUES
+    (1, 'user1', '$2a$12$Ws4/SmG865uPZwGYGJlPu.uKZMQomWa8GYTrFAqJ4EsnFTm7XBD2O', '민수', 'minsu@example.com', '민수짱', '여행을 좋아하는 사람입니다.', '2025-04-01', 'ACTIVE', 'MEMBER', 'https://randomuser.me/api/portraits/men/1.jpg'),
+    (2, 'user2', '$2a$12$lbY6ZRT88d6O8OnRfy1Phebqmm1tpxXzRHZX1OWSzNoeV4Xn6mD62', '지연', 'jiyeon@example.com', '지연쨩', '카페 탐방러.', '2025-04-02', 'ACTIVE', 'MEMBER', 'https://randomuser.me/api/portraits/women/2.jpg'),
+    (3, 'user3', '$2a$12$SJYlhyzE4ry200.3ela9dOzwK4uaL.bbzEXhevtzSEsq2MbDC9JP.', '동혁', 'donghyuk@example.com', '혁혁혁', '서핑을 좋아하는 개발자.', '2025-04-03', 'ACTIVE', 'MEMBER', 'https://randomuser.me/api/portraits/men/3.jpg');
 
 insert into member
-(login_id, password, email, role, birth, nickname)
+(login_id, password, name, email, nickname, created_at, status, role, profile_image)
 values
-    ("admin01", "$2a$12$reDJjzovF8o.IYnFdcbtNuEoS0GKrS6.23yWYUB3stQ5wB2YftHcG"
-    , "admin01@test.com", "ADMIN", "2000-03-09", "admin01");
+    (
+        "admin01",
+        "$2a$12$reDJjzovF8o.IYnFdcbtNuEoS0GKrS6.23yWYUB3stQ5wB2YftHcG",
+        "관리자",
+        "admin01@test.com",
+        "ADMIN",
+        "2000-03-09",
+        "ACTIVE",
+        "ADMIN",
+        null
+    );


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
회원 더미데이터 (게시글에 있던 데이터로 수정 및 비밀번호 BCrypt 적용된 버전 저장)
JWT Filter, JWT Util 연결
이제 헤더값에 access_token을 넣으면, 그걸 토대로 인증 완료될 시에 API 통신 가능
## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> 예: `feature/게시글-작성`

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/login

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)
- close #29 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/86b3f844-b2fd-432d-aa20-a9b53776f8fe)
토큰이 일치하지 않을 때
![image](https://github.com/user-attachments/assets/d474037d-d4ce-44ae-9e02-5c5183daa6c2)

