### PR TITLE
[FEAT] 로그아웃, refresh token 도입

### DIFF
--- a/src/main/java/com/leesang/mylocaldiary/auth/controller/AuthController.java
+++ b/src/main/java/com/leesang/mylocaldiary/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.leesang.mylocaldiary.auth.dto.RequestSignUpDTO;
 import com.leesang.mylocaldiary.auth.dto.RequestVerifyEmailDTO;
 import com.leesang.mylocaldiary.auth.service.AuthService;
 import com.leesang.mylocaldiary.common.response.CommonResponseVO;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/leesang/mylocaldiary/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/leesang/mylocaldiary/auth/service/AuthServiceImpl.java
@@ -4,17 +4,26 @@ import com.leesang.mylocaldiary.auth.dto.RequestEmailDTO;
 import com.leesang.mylocaldiary.auth.dto.RequestSignUpDTO;
 import com.leesang.mylocaldiary.auth.dto.RequestVerifyEmailDTO;
 import com.leesang.mylocaldiary.common.exception.GlobalException;
+import com.leesang.mylocaldiary.common.response.CommonResponseVO;
 import com.leesang.mylocaldiary.email.service.EmailAuthService;
 import com.leesang.mylocaldiary.email.service.EmailSendService;
 import com.leesang.mylocaldiary.member.aggregate.MemberEntity;
 import com.leesang.mylocaldiary.member.repository.MemberRepository;
 import com.leesang.mylocaldiary.common.exception.ErrorCode;
+import com.leesang.mylocaldiary.redis.config.RedisConfig;
+import com.leesang.mylocaldiary.security.jwt.JwtProvider;
+import com.leesang.mylocaldiary.security.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.Random;
 
 @Service
@@ -30,7 +39,10 @@ public class AuthServiceImpl implements AuthService {
     public AuthServiceImpl(EmailAuthService emailAuthService,
                            EmailSendService emailSendService,
                            MemberRepository memberRepository,
-                           PasswordEncoder passwordEncoder) {
+                           PasswordEncoder passwordEncoder,
+                           JwtUtil jwtUtil,
+                           JwtProvider jwtProvider,
+                           RedisTemplate redisTemplate) {
         this.emailAuthService = emailAuthService;
         this.emailSendService = emailSendService;
         this.memberRepository = memberRepository;

--- a/src/main/java/com/leesang/mylocaldiary/common/exception/ErrorCode.java
+++ b/src/main/java/com/leesang/mylocaldiary/common/exception/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode {
     EMAIL_VERIFICATION_EXPIRED(HttpStatus.UNAUTHORIZED, "이메일 인증 시간이 만료되었습니다."),
     EMAIL_VERIFICATION_MISMATCH(HttpStatus.UNAUTHORIZED, "이메일 인증 코드가 일치하지 않습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "인증되지 않는 이메일입니다."),
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용중인 이메일입니다.");
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용중인 이메일입니다."),
+    REFRESH_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다. 재로그인 하십시오."),
+    TOKEN_NOT_EQUALS(HttpStatus.UNAUTHORIZED, "토큰이 일치하지 않습니다. 다시 로그인 해주시길 바랍니다."),
+    TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "허용되지 않은 접근입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/leesang/mylocaldiary/member/controller/MemberController.java
+++ b/src/main/java/com/leesang/mylocaldiary/member/controller/MemberController.java
@@ -1,6 +1,12 @@
 package com.leesang.mylocaldiary.member.controller;
 
+import com.leesang.mylocaldiary.common.response.CommonResponseVO;
+import com.leesang.mylocaldiary.member.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,8 +14,32 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/member")
 public class MemberController {
 
+    private final MemberService memberService;
+
+    @Autowired
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
     @GetMapping("/testJwtFilter")
     public String testJwtFilter() {
         return "testJwtFilter";
+    }
+
+    /* 설명. 토큰 재발급 */
+    @PostMapping("/reissue")
+    public ResponseEntity<CommonResponseVO<?>> reissueToken(HttpServletRequest request) {
+        return memberService.reissueAccessToken(request);
+    }
+
+    /* 설명. 로그아웃(토큰 무효화) */
+    @PostMapping("/logout")
+    public ResponseEntity<CommonResponseVO<?>> logout(HttpServletRequest request) {
+        memberService.logout(request);
+        return ResponseEntity.ok(CommonResponseVO.builder()
+                .status(200)
+                .message("로그아웃이 완료되었습니다.")
+                .data(null)
+                .build());
     }
 }

--- a/src/main/java/com/leesang/mylocaldiary/member/service/MemberService.java
+++ b/src/main/java/com/leesang/mylocaldiary/member/service/MemberService.java
@@ -1,0 +1,11 @@
+package com.leesang.mylocaldiary.member.service;
+
+import com.leesang.mylocaldiary.common.response.CommonResponseVO;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+
+public interface MemberService {
+    ResponseEntity<CommonResponseVO<?>> reissueAccessToken(HttpServletRequest request);
+
+    void logout(HttpServletRequest request);
+}

--- a/src/main/java/com/leesang/mylocaldiary/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/leesang/mylocaldiary/member/service/MemberServiceImpl.java
@@ -1,0 +1,103 @@
+package com.leesang.mylocaldiary.member.service;
+
+import com.leesang.mylocaldiary.common.exception.ErrorCode;
+import com.leesang.mylocaldiary.common.exception.GlobalException;
+import com.leesang.mylocaldiary.common.response.CommonResponseVO;
+import com.leesang.mylocaldiary.member.repository.MemberRepository;
+import com.leesang.mylocaldiary.security.jwt.JwtProvider;
+import com.leesang.mylocaldiary.security.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+public class MemberServiceImpl implements MemberService {
+
+    private MemberRepository memberRepository;
+    private JwtUtil jwtUtil;
+    private JwtProvider jwtProvider;
+    private RedisTemplate redisTemplate;
+
+    @Autowired
+    public MemberServiceImpl(MemberRepository memberRepository,
+                             JwtUtil jwtUtil,
+                             JwtProvider jwtProvider,
+                             RedisTemplate redisTemplate) {
+        this.memberRepository = memberRepository;
+        this.jwtUtil = jwtUtil;
+        this.jwtProvider = jwtProvider;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    @Transactional
+    public ResponseEntity<CommonResponseVO<?>> reissueAccessToken(HttpServletRequest request) {
+        // 1. 토큰 꺼내기 (헤더에서 추출)
+        String accessToken = jwtUtil.extractAccessToken(request);
+        String refreshToken = jwtUtil.extractRefreshToken(request);
+
+        // 2. Refresh 유효성 체크
+        if (!jwtUtil.validateToken(refreshToken)) {
+            throw new GlobalException(ErrorCode.REFRESH_EXPIRED);
+        }
+
+        // 3. 블랙리스트 확인
+        String blacklistKey = "Blacklist:" + accessToken;
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(blacklistKey))) {
+            throw new GlobalException(ErrorCode.TOKEN_BLACKLISTED);
+        }
+        // 4. memberId 추출 (subject에 있음)
+        Long memberId = jwtUtil.getUserIdFromToken(refreshToken);
+
+        // 5. Redis에 저장된 Refresh Token과 비교
+        String redisKey = "Refresh-Token:" + memberId;
+        String savedRefreshToken = (String) redisTemplate.opsForValue().get(redisKey);
+
+        if (savedRefreshToken == null || !refreshToken.equals(savedRefreshToken)) {
+            throw new GlobalException(ErrorCode.TOKEN_NOT_EQUALS);
+        }
+
+        // 6. Access 재발급 (만료된 access에서도 정보는 꺼낼 수 있음)
+        String email = jwtUtil.getEmailFromToken(accessToken);
+        String role = jwtUtil.getRoleFromToken(accessToken);
+
+        String newAccessToken = jwtProvider.generateAccessToken(memberId.intValue(), email, role);
+
+        // 7. 응답 반환
+        return ResponseEntity.ok(CommonResponseVO.builder()
+                .status(200)
+                .message("Access Token 재발급 완료")
+                .data(Map.of("accessToken", newAccessToken))
+                .build());
+    }
+
+    @Override
+    @Transactional
+    public void logout(HttpServletRequest request) {
+        String accessToken = jwtUtil.extractAccessToken(request);
+
+        Long memberId = jwtUtil.getUserIdFromToken(accessToken);
+
+        // AccessToken 만료시간 계산
+        long expiration = jwtUtil.getExpiration(accessToken);
+        String blacklistKey = "Blacklist:" + accessToken;
+
+        // 블랙리스트 추가
+        redisTemplate.opsForValue().set(blacklistKey,
+                "logout", expiration,
+                TimeUnit.MILLISECONDS);
+
+        // RefreshToken 제거
+        String refreshKey = "Refresh-Token:" + memberId;
+        redisTemplate.delete(refreshKey);
+
+    }
+}

--- a/src/main/java/com/leesang/mylocaldiary/security/jwt/JwtFilter.java
+++ b/src/main/java/com/leesang/mylocaldiary/security/jwt/JwtFilter.java
@@ -1,6 +1,5 @@
-package com.leesang.mylocaldiary.security.filter;
+package com.leesang.mylocaldiary.security.jwt;
 
-import com.leesang.mylocaldiary.security.jwt.JwtUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -11,7 +10,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
-
 import java.io.IOException;
 import java.util.Collections;
 
@@ -38,7 +36,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
             // 2. 토큰 유효성 검증
             if (jwtUtil.validateToken(token)) {
-                Claims claims = jwtUtil.getClaims(token);
+                Claims claims = jwtUtil.getClaimsAllowExpired(token);
 
                 String loginId = claims.get("email", String.class); // 🔥 우리가 넣은건 email (loginId)
                 String role = claims.get("role", String.class);
@@ -58,6 +56,8 @@ public class JwtFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authenticationToken);
                 log.info("JWT 인증 성공 - loginId: {}", loginId);
                 log.info("JWT 인증 성공 - role: {}", role);
+            } else {
+                log.warn("JWT 토큰이 유효하지 않음. 인증 처리 생략");
             }
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,8 @@ mybatis:
 
 token:
   secret: ${secret_key}
-  expiration_time: 43200000
+  access_expiration_time: 36000000      # Access Token: 15분 (900,000ms)
+  refresh_expiration_time: 604800000  # Refresh Token: 7일 (604,800,000ms)
 
 cloud:
   aws:


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
access_token에는 사용자 정보가 들어가는 점이 탈취의 위험이 존재하기 때문에
refresh token을 통해 주기적으로 재발급을 사용
프론트엔드에서 요청을 시간 맞춰서 보내는 형식을 사용할 예정
로그아웃 까지 추가 구현 로그아웃 시에는 해당 access_token을 토큰 허용시간 동안 블랙리스트로 만들어 로그아웃 된 상태에서
access_token 탈취 후 서비스 이용을 막음

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> 예: `feature/게시글-작성`

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/refresh-token

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)
- close #31 close #32  

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.
refresh token 확인
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/abbd60ff-1faf-4c8e-a945-aa9f9fa874be" />

access_token 재발급
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiZW1haWwiOiJtaW5zdUBleGFtcGxlLmNvbSIsInJvbGUiOiJST0xFX01FTUJFUiIsImlhdCI6MTc0NTk4MDIxMiwiZXhwIjoxNzQ2MDE2MjEyfQ.MWpewjVcMlUCnkoD6sE1J-e9ZMFBrJTQRqyyQGz6jVaOH_R_xalwkgH8KGkfzYaph4I0r1vyl0RUlkEYxsVK3g

로그아웃
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/0b493113-7898-416d-a3d4-7487c69c0400" />
